### PR TITLE
Fix segfault on quit.

### DIFF
--- a/source/app.d
+++ b/source/app.d
@@ -60,6 +60,7 @@ Vector2 GetMousePositionVirtual() {
     return Vector2(virtualMouseX, virtualMouseY);
 }
 
+bool shouldQuit = false; // Manual quit flag
 
 void main() {
     InitAudioDevice(); // Initialize audio device first
@@ -138,7 +139,6 @@ void main() {
     float lastTime = 0;
     float currentTime = 0;
     float frameTime = 0;
-    bool shouldQuit = false; // Manual quit flag
 
     while(!shouldQuit) {
         // Check for window close request (X button, Alt+F4, etc.) but NOT ESC
@@ -221,4 +221,7 @@ void main() {
     UnloadRenderTexture(virtualScreen); // Unload the render texture
     // Unload fonts
     // ... existing deinitialization ...
+
+    // Close Window
+    CloseWindow();
 }

--- a/source/scripts/screens/title_screen.d
+++ b/source/scripts/screens/title_screen.d
@@ -1805,7 +1805,8 @@ class TitleScreen : IScreen {
                 if (quitDialog.isDone()) {
                     // User confirmed quit and goodbye message finished
                     writeln("Application will now close");
-                    CloseWindow(); // This will close the Raylib window
+                    import app : shouldQuit;
+                    shouldQuit = true;
                 } else if (quitDialog.isCancelled()) {
                     // User cancelled quit
                     state = TitleState.MAINMENU; // Return to main menu


### PR DESCRIPTION
You can't close the window while in the middle of drawing. In Raylib `CloseWindow` means, unload all the opengl resources, and free all the raylib allocated stuff.

Feel free to rework this so it's in a better spot, this was just the easiest way to do it.